### PR TITLE
Remove redundant ‘gulp-rename’ include from Gulpfile.js

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,7 +1,6 @@
 const gulp = require('gulp');
 const sass = require('gulp-sass');
 const pug = require('gulp-pug');
-const rename = require('gulp-rename');
 const browserSync = require('browser-sync').create();
 
 gulp.task('demo', ['demo:scss', 'demo:pug'], () => {


### PR DESCRIPTION
This is required to run `gulp demo`